### PR TITLE
Update router.php

### DIFF
--- a/site/router.php
+++ b/site/router.php
@@ -140,7 +140,11 @@ function FLEXIcontentBuildRoute(&$query)
 				// IMPLICIT view ('item' NOT contained in the url), because according to configuration,
 				// the 1-segment implies --item-- view so we do not need to add /item/ segment (1st segment is view)
 			}
+			if ($cid==23) { // id for cetegory profile
+			$segments[] = 'id'.$id;
+			} else {
 			$segments[] = @$query['id'];  // suppress error since it may not be set e.g. for new item form
+			}
 		}
 		unset($query['view']);
 		unset($query['cid']);


### PR DESCRIPTION
My first PR on Github about this  - >
http://www.flexicontent.org/forum/20-general-support/54314-advance-route-about-ids-in-item-urls.html

Idea is simple:
1. flexi need userprofiles
2. full custom router  - flexi router - must be a flexible as a component

about 1 - there is a way - with categories and items as profiles - but ugly url - joomla-like style:
/menuitem/123-blabla  or /234-blablacategory/343-blabla-item

But what be if you  add an option in configuration of FC - custom route for custom category?

My changes in code create a links for items:
 site.com/users/id123
but this links give an 404 error - how to retranslate site.com/users/id123 in 
index.php?option=com_flexicontent&view=item&cid=23&id=123 for the system
